### PR TITLE
Add support for null literal assignments

### DIFF
--- a/src/parser/nodes.js
+++ b/src/parser/nodes.js
@@ -119,7 +119,7 @@ module.exports = {
       this.selectable = true;
     }
   },
-  
+
   LinkNode: class extends Link {
     constructor(text, identifier, lineNo) {
       super();
@@ -154,6 +154,14 @@ module.exports = {
       super();
       this.type = 'BooleanLiteralNode';
       this.booleanLiteral = booleanLiteral;
+    }
+  },
+
+  NullLiteralNode: class extends Literal {
+    constructor(nullLiteral) {
+      super();
+      this.type = 'NullLiteralNode';
+      this.nullLiteral = nullLiteral;
     }
   },
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -153,7 +153,7 @@ class Runner {
    * @param {any[]} selections
    */
   * handleSelections(selections) {
-    if (selections.length > 0 || selections[0] instanceof nodeTypes.Shortcut) {		  
+    if (selections.length > 0 || selections[0] instanceof nodeTypes.Shortcut) {
       // Multiple options to choose from (or just a single shortcut)
       // Filter out any conditional dialog options that result to false
       const filteredSelections = selections.filter((s) => {
@@ -304,6 +304,8 @@ class Runner {
         return node.stringLiteral;
       } else if (node.type === 'BooleanLiteralNode') {
         return node.booleanLiteral === 'true';
+      } else if (node.type === 'NullLiteralNode') {
+        return null;
       } else if (node.type === 'VariableNode') {
         return this.variables.get(node.variableName);
       } else if (node.type === 'FunctionResultNode') {

--- a/tests/test_runner.js
+++ b/tests/test_runner.js
@@ -284,6 +284,40 @@ describe('Dialogue', () => {
     expect(run.next().done).to.be.true;
   });
 
+  it('Can evaluate a null assignment', () => {
+    runner.load(assignmentYarnData);
+    const run = runner.run('Null');
+
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line', value.data, value.lineNum));
+
+    expect(runner.variables.get('testvar')).to.be.undefined;
+
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line After', value.data, value.lineNum));
+
+    expect(runner.variables.get('testvar')).to.equal(null);
+
+    expect(run.next().done).to.be.true;
+  });
+
+  it('Can evaluate a null assignment with expression', () => {
+    runner.load(assignmentYarnData);
+    const run = runner.run('NullExpression');
+
+    let value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line', value.data, value.lineNum));
+
+    expect(runner.variables.get('testvar')).to.be.undefined;
+
+    value = run.next().value;
+    expect(value).to.deep.equal(new bondage.TextResult('Test Line After', value.data, value.lineNum));
+
+    expect(runner.variables.get('testvar')).to.equal(null);
+
+    expect(run.next().done).to.be.true;
+  });
+
   it('Can evaluate an assignment from one variable to another', () => {
     runner.load(assignmentYarnData);
     const run = runner.run('Variable');

--- a/tests/yarn_files/assignment.json
+++ b/tests/yarn_files/assignment.json
@@ -59,6 +59,26 @@
 		"colorID": 0
 	},
 	{
+		"title": "Null",
+		"tags": "Tag",
+		"body": "Test Line\n<<set $testvar = null>>\nTest Line After",
+		"position": {
+			"x": 449,
+			"y": 252
+		},
+		"colorID": 0
+	},
+	{
+		"title": "NullExpression",
+		"tags": "Tag",
+		"body": "Test Line\n<<set $testvar = (false || null) && (!true || null)>>\nTest Line After",
+		"position": {
+			"x": 449,
+			"y": 252
+		},
+		"colorID": 0
+	},
+	{
 		"title": "Variable",
 		"tags": "Tag",
 		"body": "Test Line\n<<set $firstvar = \"First variable string\">><<set $secondvar = $firstvar>>\nTest Line After",


### PR DESCRIPTION
This PR adds support for `null` literal assignments, which was missing somehow. Please review at your convenience. Thanks!